### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -31,10 +31,10 @@ ServoOut	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin KEYWORD2
+begin	KEYWORD2
 step	KEYWORD2
 
-setup KEYWORD2
+setup	KEYWORD2
 update	KEYWORD2
 
 pin	KEYWORD2
@@ -47,10 +47,10 @@ put	KEYWORD2
 isOn	KEYWORD2
 isOff	KEYWORD2
 get	KEYWORD2
-getInt KEYWORD2
+getInt	KEYWORD2
 
-smooth KEYWORD2
-noSmooth KEYWORD2
+smooth	KEYWORD2
+noSmooth	KEYWORD2
 
 randomUniform	KEYWORD2
 seconds	KEYWORD2


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords